### PR TITLE
Re-run acceptance CA cert; move condition to main task

### DIFF
--- a/ansible/roles/deploy-crc-cloud/tasks/accept_cert.yaml
+++ b/ansible/roles/deploy-crc-cloud/tasks/accept_cert.yaml
@@ -1,29 +1,27 @@
 ---
-- name: Get csr in Pending state
-  ansible.builtin.shell: |
-    oc get csr --no-headers | awk '/Pending/ {print $1}'
-  register: _pending_csr
+- name: Re-run accept certificates in Pending state few times
+  ansible.builtin.shell: >
+    set -o pipefail;
+    oc get csr --no-headers |
+    awk '/Pending/ {print $1}' |
+    xargs --no-run-if-empty oc adm certificate approve
+  loop: "{{ range(1, 4) | list }}"
+  loop_control:
+    pause: 10
+  ignore_errors: true
+  changed_when: false
 
-- name: Accept OpenShift certificate if in Pending state
-  when: _pending_csr.stdout_lines | length > 0
-  ansible.builtin.shell: |
-    oc adm certificate approve {{ item }}
-  loop: "{{ _pending_csr.stdout_lines }}"
+- name: Create service account for - auto-csr-approver
+  ansible.builtin.copy:
+    src: cluster-cert-approver.yaml
+    dest: /tmp/cluster-cert-approver.yaml
+    mode: "0644"
 
-- name: Create cron job for accepting cert
-  when: ca_cert_approver | bool
-  block:
-    - name: Create service account for - auto-csr-approver
-      ansible.builtin.copy:
-        src: cluster-cert-approver.yaml
-        dest: /tmp/cluster-cert-approver.yaml
-        mode: "0644"
-
-    - name: Apply cluster cert approver
-      ansible.builtin.command: |
-        oc apply -f /tmp/cluster-cert-approver.yaml
-      register: _cert_approver
-      until: _cert_approver.rc != 1
-      retries: 60
-      delay: 10
-      changed_when: false
+- name: Apply cluster cert approver
+  ansible.builtin.command: |
+    oc apply -f /tmp/cluster-cert-approver.yaml
+  register: _cert_approver
+  until: _cert_approver.rc == 0
+  retries: 60
+  delay: 10
+  changed_when: false

--- a/ansible/roles/deploy-crc-cloud/tasks/main.yaml
+++ b/ansible/roles/deploy-crc-cloud/tasks/main.yaml
@@ -17,6 +17,7 @@
   ansible.builtin.include_tasks: pubkey.yaml
 
 - name: Accept certificate
+  when: ca_cert_approver | bool
   ansible.builtin.include_tasks: accept_cert.yaml
 
 - name: Wait for cluster become healthy


### PR DESCRIPTION
It happens, that the command for accepting cert require to be executed
few times and until cron job is not created, something needs to accept
the cert.
Also move condition to main task, because the tasks should be only
executed when variable 'ca_cert_approver' is true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Streamlined certificate approval to batch-process pending CSRs, reducing repetitive per-item operations and simplifying flow.
  * Added a configuration-driven guard to enable or disable the certificate approval step, giving deployments conditional control over when approvals run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->