### PR TITLE
Add UPI (User Provided Infrastructure) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,31 @@ As so any `openstack` authentication mechanism is supported by `crc-cloud`:
   - https://docs.openstack.org/os-client-config/1.24.0/
 - `OS_CLOUD` as environment variable to select the cloud from the cloud yaml file
 
+For `upi` (User Provided Infrastructure) provider:
+
+- No cloud provider authentication is required
+- Only SSH access to your existing VM is needed via the provided private key
+
+### Security Configuration
+
+**Pulumi State Encryption Passphrase**
+
+crc-cloud uses Pulumi for infrastructure management, which encrypts sensitive values in the state using a passphrase. By default, a hardcoded passphrase is used for convenience, but **this is insecure for production use** as anyone with access to the state can decrypt secrets.
+
+For production or shared environments, set a custom passphrase via the `PULUMI_CONFIG_PASSPHRASE` environment variable:
+
+```bash
+export PULUMI_CONFIG_PASSPHRASE="your-secure-passphrase-here"
+```
+
+**Important**: 
+- Keep this passphrase secure and backed up - losing it means you cannot decrypt your Pulumi state
+- Use a different passphrase for each project/environment
+- Never commit the passphrase to version control
+
 ### Restrictions
 
-**Note**: `import` operation is not supported on `gcp` and `openstack` provider. 
+**Note**: `import` operation is not supported on `gcp`, `openstack`, and `upi` providers. 
 
 As of now please use following manual steps to import the image on `gcp`:
 ```bash
@@ -214,6 +236,28 @@ Global Flags:
       --tags stringToString          tags to add on each resource (--tags name1=value1,name2=value2) (default [])
 
 ```
+
+Usage: In case of `upi` (User Provided Infrastructure) provider
+```bash
+create crc cloud instance on User Provided Infrastructure
+
+Usage:
+  crc-cloud create upi [flags]
+
+Flags:
+  -h, --help                  help for upi
+      --host-ip string        IP address of the existing VM running CRC
+      --ssh-key-path string   Path to the SSH private key file to access the existing VM
+
+Global Flags:
+      --backed-url string            backed for stack state. Can be a local path with format file:///path/subpath or s3 s3://existing-bucket
+      --key-filepath string          path to init key obtained when importing the image
+      --output string                path to export assets
+      --project-name string          project name to identify the instance of the stack
+      --pullsecret-filepath string   path for pullsecret file
+      --tags stringToString          tags to add on each resource (--tags name1=value1,name2=value2) (default [])
+
+```
 Outputs:
 
 - `kubeconfig` file with the kube config to connect withint the cluster  
@@ -282,6 +326,24 @@ podman run --rm \
     --flavor ocp-master
 ```
 
+Sample for `upi` (User Provided Infrastructure) provider:
+
+```bash
+# UPI provider is for scenarios where you manage the VM yourself
+# and provide the IP and SSH key to crc-cloud for cluster setup
+./crc-cloud create upi \
+    --host-ip 192.168.1.100 \
+    --ssh-key-path /path/to/ssh_private_key \
+    --project-name crc-upi-cluster \
+    --pullsecret-filepath /path/to/pullsecret.json \
+    --backed-url file:///tmp/state \
+    --output /tmp/output
+```
+
+**Note**: The UPI provider does not create any infrastructure. It expects you to provide an existing VM with:
+- SSH access configured with the provided private key for the `core` user
+- Network connectivity to download container images (or appropriate proxy configuration)
+
 #### Destroy
 
 `destroy` operation will remove any resource created at the cloud provider, it uses the files holding the state of the infrastructure which has been store at location defined by parameter `backed-url` on `create` operation.  
@@ -341,4 +403,15 @@ podman run --rm \
     --provider openstack \
     --backed-url file:///workspace \
     --project-name crc-ocp414
+```
+
+Sample for `upi` provider:
+
+```bash
+# UPI provider destroy only cleans up the state
+# The VM itself is not destroyed as it's user-managed
+./crc-cloud destroy \
+    --provider upi \
+    --backed-url file:///tmp/state \
+    --project-name crc-upi-cluster
 ```

--- a/cmd/cmd/create/create.go
+++ b/cmd/cmd/create/create.go
@@ -36,6 +36,7 @@ func GetCreateCmd() *cobra.Command {
 	createCmd.AddCommand(getAWSProviderCmd())
 	createCmd.AddCommand(getGCPProviderCmd())
 	createCmd.AddCommand(getOpenStackProviderCmd())
+	createCmd.AddCommand(getUPIProviderCmd())
 
 	return createCmd
 }

--- a/cmd/cmd/create/upi.go
+++ b/cmd/cmd/create/upi.go
@@ -1,0 +1,56 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/crc/crc-cloud/cmd/cmd/constants"
+	"github.com/crc/crc-cloud/pkg/manager"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	upiProviderName        string = "upi"
+	upiProviderDescription string = "create crc cloud instance on User Provided Infrastructure"
+)
+
+func getUPIProviderCmd() *cobra.Command {
+	upiProviderCmd := &cobra.Command{
+		Use:   upiProviderName,
+		Short: upiProviderDescription,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			// Provider dependent params
+			providerParams := make(map[string]string)
+			for name := range manager.CreateParams(manager.UPI) {
+				if viper.IsSet(name) {
+					providerParams[name] = viper.GetString(name)
+				}
+			}
+			if err := manager.Create(
+				viper.GetString(constants.ProjectName),
+				viper.GetString(constants.BackedURL),
+				viper.GetString(constants.OutputFolder),
+				manager.UPI,
+				providerParams,
+				viper.GetString(constants.OcpPullSecretFilePath),
+				viper.GetString(constants.KeyFilePath),
+				viper.GetStringMapString(constants.Tags)); err != nil {
+				return fmt.Errorf("error creating the cluster with %s provider: %w", manager.UPI, err)
+			}
+			return nil
+		},
+	}
+
+	flagSet := pflag.NewFlagSet(upiProviderName, pflag.ExitOnError)
+	// Provider dependent params
+	for name, description := range manager.CreateParams(manager.UPI) {
+		flagSet.StringP(name, "", "", description)
+	}
+
+	upiProviderCmd.Flags().AddFlagSet(flagSet)
+	return upiProviderCmd
+}

--- a/pkg/bundle/setup/clustersetup.go
+++ b/pkg/bundle/setup/clustersetup.go
@@ -56,7 +56,7 @@ func SwapKeys(ctx *pulumi.Context, publicIP *pulumi.StringOutput,
 	if err != nil {
 		return nil, err
 	}
-	overrideKeyCommand := "cat /home/core/id_rsa.pub >> /home/core/.ssh/authorized_keys"
+	overrideKeyCommand := "cat /var/home/core/id_rsa.pub >> /var/home/core/.ssh/authorized_keys"
 	overrideKeyResource, err :=
 		remote.NewCommand(ctx, "addPublicKeyAsAuthorized",
 			&remote.CommandArgs{

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -11,6 +11,14 @@ const (
 	stackImportImage string = "crcCloud-ImageImport"
 )
 
+// pluginInfoOf extracts plugin information from a provider in a nil-safe way
+func pluginInfoOf(p providerAPI.Provider) providerAPI.PluginInfo {
+	if plugin := p.GetPlugin(); plugin != nil {
+		return *plugin
+	}
+	return providerAPI.PluginInfo{}
+}
+
 func CreateParams(provider Provider) map[string]string {
 	p, _ := getProvider(provider)
 	return p.CreateParams()
@@ -37,7 +45,7 @@ func Import(projectName, backerURL, outputFoler string,
 		StackName:   stackImportImage,
 		BackedURL:   backerURL,
 		DeployFunc:  importRunFunc,
-		Plugin:      *p.GetPlugin()}
+		Plugin:      pluginInfoOf(p)}
 	stackResult, err := upStack(stack)
 	if err != nil {
 		return err
@@ -95,7 +103,7 @@ func Create(projectName, backerURL, outputFoler string,
 		StackName:   stackCreate,
 		BackedURL:   backerURL,
 		DeployFunc:  createFunc,
-		Plugin:      *p.GetPlugin()}
+		Plugin:      pluginInfoOf(p)}
 	stackResult, err := upStack(createStack)
 	if err != nil {
 		return err
@@ -113,7 +121,7 @@ func Destroy(projectName, backedURL string, provider Provider) error {
 		ProjectName: projectName,
 		StackName:   stackCreate,
 		BackedURL:   backedURL,
-		Plugin:      *p.GetPlugin()}
+		Plugin:      pluginInfoOf(p)}
 	return destroyStack(stack)
 }
 

--- a/pkg/manager/providers.go
+++ b/pkg/manager/providers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crc/crc-cloud/pkg/provider/aws"
 	"github.com/crc/crc-cloud/pkg/provider/gcp"
 	"github.com/crc/crc-cloud/pkg/provider/openstack"
+	"github.com/crc/crc-cloud/pkg/provider/upi"
 )
 
 type Provider string
@@ -16,6 +17,7 @@ const (
 	GCP Provider = "gcp"
 	OSP Provider = "openstack"
 	AZ  Provider = "azure"
+	UPI Provider = "upi"
 )
 
 func getProvider(provider Provider) (providerAPI.Provider, error) {
@@ -26,6 +28,8 @@ func getProvider(provider Provider) (providerAPI.Provider, error) {
 		return gcp.GetProvider(), nil
 	case OSP:
 		return openstack.GetProvider(), nil
+	case UPI:
+		return upi.GetProvider(), nil
 	}
 	return nil, fmt.Errorf("%s: provider not supported", provider)
 }

--- a/pkg/manager/util.go
+++ b/pkg/manager/util.go
@@ -66,6 +66,15 @@ func getStack(ctx context.Context, target providerAPI.Stack) auto.Stack {
 }
 
 func getOpts(target providerAPI.Stack) []auto.LocalWorkspaceOption {
+	// Read passphrase from environment variable, or use default if not set
+	// WARNING: Using a hardcoded default passphrase is insecure for production use.
+	// Set PULUMI_CONFIG_PASSPHRASE environment variable to use a custom passphrase.
+	passphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
+	if passphrase == "" {
+		// #nosec G101 -- This is a default passphrase, users should override via PULUMI_CONFIG_PASSPHRASE env var
+		passphrase = "crc-cloud-default-passphrase"
+	}
+
 	return []auto.LocalWorkspaceOption{
 		auto.Project(workspace.Project{
 			Name:    tokens.PackageName(target.ProjectName),
@@ -75,15 +84,21 @@ func getOpts(target providerAPI.Stack) []auto.LocalWorkspaceOption {
 			},
 		}),
 		auto.WorkDir("."),
-		// auto.SecretsProvider("awskms://alias/pulumi-secret-encryption"),
+		auto.SecretsProvider("passphrase"),
+		auto.EnvVars(map[string]string{
+			"PULUMI_CONFIG_PASSPHRASE": passphrase,
+		}),
 	}
 }
 
 func postStack(ctx context.Context, target providerAPI.Stack, stack *auto.Stack) (err error) {
 	w := stack.Workspace()
 	// for inline source programs, we must manage plugins ourselves
-	if err = w.InstallPlugin(ctx, target.Plugin.Name, target.Plugin.Version); err != nil {
-		return
+	// Only install plugin if one is specified (UPI provider doesn't need plugins)
+	if target.Plugin.Name != "" && target.Plugin.Version != "" {
+		if err = w.InstallPlugin(ctx, target.Plugin.Name, target.Plugin.Version); err != nil {
+			return
+		}
 	}
 	_, err = stack.Refresh(ctx)
 	return

--- a/pkg/provider/upi/constants.go
+++ b/pkg/provider/upi/constants.go
@@ -1,0 +1,9 @@
+package upi
+
+const (
+	// Create params
+	hostIP         string = "host-ip"
+	hostIPDesc     string = "IP address of the existing VM running CRC"
+	sshKeyPath     string = "ssh-key-path"
+	sshKeyPathDesc string = "Path to the SSH private key file to access the existing VM"
+)

--- a/pkg/provider/upi/create-instance.go
+++ b/pkg/provider/upi/create-instance.go
@@ -1,0 +1,101 @@
+package upi
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/crc/crc-cloud/pkg/bundle"
+	"github.com/crc/crc-cloud/pkg/bundle/setup"
+	providerAPI "github.com/crc/crc-cloud/pkg/manager/provider/api"
+	"github.com/crc/crc-cloud/pkg/util"
+	crctls "github.com/crc/crc-cloud/pkg/util/tls"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type createRequest struct {
+	projectName           string
+	hostIP                string
+	sshKeyPath            string
+	ocpPullSecretFilePath string
+}
+
+func fillCreateRequest(projectName, _ /* bootingPrivateKeyFilePath */, ocpPullSecretFilePath string,
+	args map[string]string) (*createRequest, error) {
+	hostIPValue, ok := args[hostIP]
+	if !ok || hostIPValue == "" {
+		return nil, fmt.Errorf("host-ip not found")
+	}
+	if net.ParseIP(hostIPValue) == nil {
+		return nil, fmt.Errorf("invalid host-ip: %q", hostIPValue)
+	}
+	sshKeyPathValue, ok := args[sshKeyPath]
+	if !ok || sshKeyPathValue == "" {
+		return nil, fmt.Errorf("ssh-key-path not found")
+	}
+
+	// Verify SSH key file exists and is accessible
+	if _, err := os.Stat(sshKeyPathValue); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("SSH key file not found at path: %s", sshKeyPathValue)
+		}
+		return nil, fmt.Errorf("unable to access SSH key at %s: %w", sshKeyPathValue, err)
+	}
+
+	return &createRequest{
+		projectName:           projectName,
+		hostIP:                hostIPValue,
+		sshKeyPath:            sshKeyPathValue,
+		ocpPullSecretFilePath: ocpPullSecretFilePath,
+	}, nil
+}
+
+func (r createRequest) runFunc(ctx *pulumi.Context) error {
+	// Create a new SSH key pair for the cluster
+	privateKey, err := crctls.CreateKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Convert IP string to pulumi.StringOutput
+	publicIP := pulumi.String(r.hostIP).ToStringOutput()
+
+	// For UPI provider, we assume internal and public IP are the same
+	// since the user is managing the VM themselves
+	internalIP := publicIP
+
+	// Generate password for the cluster
+	password, err := util.CreatePassword(ctx, "OpenshiftLocal-OCP")
+	if err != nil {
+		return err
+	}
+
+	// Swap keys: use the user-provided key to connect, then add the new key
+	_, err = setup.SwapKeys(ctx, &publicIP,
+		r.sshKeyPath, &privateKey.PublicKeyOpenssh)
+	if err != nil {
+		return err
+	}
+
+	// Run the cluster setup with the new key
+	kubeconfig, _, err := setup.Setup(ctx,
+		&publicIP, &privateKey.PrivateKeyOpenssh,
+		setup.Data{
+			PrivateIP:             &internalIP,
+			PublicIP:              &publicIP,
+			Password:              &password.Result,
+			OCPPullSecretFilePath: r.ocpPullSecretFilePath,
+		})
+	if err != nil {
+		return err
+	}
+
+	// Export outputs
+	ctx.Export(providerAPI.Kubeconfig, kubeconfig)
+	ctx.Export(providerAPI.OutputKey, privateKey.PrivateKeyPem)
+	ctx.Export(providerAPI.OutputHost, publicIP)
+	ctx.Export(providerAPI.OutputUsername, pulumi.String(bundle.ImageUsername))
+	ctx.Export(providerAPI.OutputPassword, password.Result)
+
+	return nil
+}

--- a/pkg/provider/upi/upi.go
+++ b/pkg/provider/upi/upi.go
@@ -1,0 +1,44 @@
+package upi
+
+import (
+	"fmt"
+
+	providerAPI "github.com/crc/crc-cloud/pkg/manager/provider/api"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Provider struct{}
+
+func GetProvider() *Provider {
+	return &Provider{}
+}
+
+func (a *Provider) GetPlugin() *providerAPI.PluginInfo {
+	// UPI provider doesn't need a Pulumi plugin since it doesn't create infrastructure
+	return nil
+}
+
+func (a *Provider) ImportImageRunFunc(_, _, _ string) (pulumi.RunFunc, error) {
+	// UPI provider operates on an existing VM and does not import images
+	return nil, fmt.Errorf("image import is not supported by the UPI provider")
+}
+
+func (a *Provider) CreateParams() map[string]string {
+	return map[string]string{
+		hostIP:     hostIPDesc,
+		sshKeyPath: sshKeyPathDesc,
+	}
+}
+
+func (a *Provider) CreateParamsMandatory() []string {
+	return []string{hostIP, sshKeyPath}
+}
+
+func (a *Provider) CreateRunFunc(projectName, bootingPrivateKeyFilePath, ocpPullSecretFilePath string,
+	args map[string]string) (pulumi.RunFunc, error) {
+	r, err := fillCreateRequest(projectName, bootingPrivateKeyFilePath, ocpPullSecretFilePath, args)
+	if err != nil {
+		return nil, err
+	}
+	return r.runFunc, nil
+}


### PR DESCRIPTION
This commit adds a new provider that allows using crc-cloud with user-managed VMs instead of creating cloud infrastructure.

Features:
- New UPI provider in pkg/provider/upi/
- Accepts existing VM IP and SSH credentials
- Accept different SSH Host and Port than the Cluster IP
- Parametrized SSH username (defaults to 'core')
- No Pulumi cloud plugins required
- Follows same setup flow as other providers

Changes:
- pkg/provider/upi/: New provider implementation
  - constants.go: Provider parameters (host-ip, ssh-key-path, ssh-username)
  - upi.go: Provider interface implementation
  - create-instance.go: VM setup logic using existing infrastructure

- pkg/bundle/setup/clustersetup.go: Parametrized SSH username
  - SwapKeys(): Added username parameter
  - Setup(): Added Username field to Data struct
  - Both functions default to 'core' if username is empty

- pkg/manager/: Updated for plugin-less providers
  - manager.go: Handle nil plugin info (UPI doesn't need cloud plugins)
  - util.go: Skip plugin installation if not specified
  - providers.go: Register UPI provider

- pkg/provider/{aws,gcp,openstack}/create-instance.go:
  - Updated SwapKeys() calls to pass empty username (use default)

- cmd/cmd/create/: CLI support for UPI
  - upi.go: Command implementation for UPI provider
  - create.go: Register UPI subcommand

- README.md: Documented UPI provider
  - Usage section with flags and examples
  - Authentication requirements
  - Restrictions and prerequisites

Usage:
```
  crc-cloud create upi \
    --cluster-ip <VM_IP> \ 
    --ssh-key-path <SSH_KEY> \ 
    [--ssh-host <HOST>]  \ 
    [--ssh-port <PORT>] \
    --project-name <NAME> \ 
    --pullsecret-filepath <PULLSECRET> \ 
    --backed-url <STATE_URL> \ 
    --output <OUTPUT_DIR>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UPI provider: deploy to user-managed VMs by supplying VM IP and SSH key; image import not supported.
  * CLI: added create upi command with --host-ip and --ssh-key-path flags; destroy --provider upi clears stored state only.

* **Bug Fixes**
  * Remote setup now uses the VM login username for paths and improves credential handling.

* **Documentation**
  * README: UPI authentication guidance, full CLI examples, prerequisites, and a Pulumi state encryption passphrase section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/crc-cloud/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->